### PR TITLE
feat: add sample-data fallback when restaurant/menu API fails

### DIFF
--- a/client/src/components/common/SampleDataNotice.js
+++ b/client/src/components/common/SampleDataNotice.js
@@ -1,0 +1,22 @@
+/**
+ * SampleDataNotice
+ *
+ * A small, non-intrusive banner shown when the UI is rendering fallback
+ * sample data because the live API was unavailable or returned no data.
+ * Keeps users (and developers) from mistaking demo content for live data.
+ */
+const SampleDataNotice = ({
+  message = "Showing sample data — live data is currently unavailable.",
+}) => {
+  return (
+    <div
+      role="status"
+      className="mx-4 my-2 flex items-center gap-2 rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-800"
+    >
+      <span aria-hidden="true">⚠️</span>
+      <span>{message}</span>
+    </div>
+  );
+};
+
+export default SampleDataNotice;

--- a/client/src/data/sampleMenu.js
+++ b/client/src/data/sampleMenu.js
@@ -1,0 +1,184 @@
+/**
+ * Sample Menu Data (Fallback)
+ *
+ * A realistic restaurant menu shaped to match exactly what `hooks/useMenu`
+ * returns to the Menu page: a flattened object with restaurant info plus a
+ * `filterCategory` array whose entries are `{ card: { card: { categoryId,
+ * title, itemCards } } }` and whose items are `{ card: { info } }`.
+ *
+ * Used as a graceful fallback when the menu API errors out or returns no
+ * usable data. Item `imageId` is intentionally left empty so the UI renders
+ * its built-in DEFAULT_FOOD_IMAGE instead of an invented (broken) URL.
+ */
+
+/**
+ * @param {string} id
+ * @param {string} name
+ * @param {number} priceInPaise - Price in paise (UI divides by 100).
+ * @param {string} description
+ * @param {boolean} isVeg
+ */
+const makeItem = (id, name, priceInPaise, description, isVeg) => ({
+  card: {
+    info: {
+      id,
+      name,
+      price: priceInPaise,
+      description,
+      imageId: "", // falls back to DEFAULT_FOOD_IMAGE in MenuBody
+      isVeg: isVeg ? 1 : 0,
+    },
+  },
+});
+
+/**
+ * @param {string} categoryId
+ * @param {string} title
+ * @param {Array} itemCards
+ */
+const makeCategory = (categoryId, title, itemCards) => ({
+  card: {
+    card: {
+      "@type": "type.googleapis.com/swiggy.presentation.food.v2.ItemCategory",
+      categoryId,
+      title,
+      itemCards,
+    },
+  },
+});
+
+const filterCategory = [
+  makeCategory("cat-recommended", "Recommended", [
+    makeItem(
+      "item-1",
+      "Paneer Butter Masala",
+      29900,
+      "Cottage cheese simmered in a rich, buttery tomato gravy.",
+      true,
+    ),
+    makeItem(
+      "item-2",
+      "Butter Chicken",
+      34900,
+      "Tandoori chicken in a creamy makhani sauce, a house favourite.",
+      false,
+    ),
+    makeItem(
+      "item-3",
+      "Veg Hakka Noodles",
+      21900,
+      "Wok-tossed noodles with crunchy vegetables and house sauces.",
+      true,
+    ),
+    makeItem(
+      "item-4",
+      "Chicken Biryani",
+      31900,
+      "Long-grain basmati layered with spiced chicken and saffron.",
+      false,
+    ),
+  ]),
+  makeCategory("cat-starters", "Starters", [
+    makeItem(
+      "item-5",
+      "Crispy Corn",
+      18900,
+      "Golden-fried sweet corn tossed with pepper and herbs.",
+      true,
+    ),
+    makeItem(
+      "item-6",
+      "Chicken 65",
+      26900,
+      "Spicy, crispy fried chicken with curry leaves.",
+      false,
+    ),
+    makeItem(
+      "item-7",
+      "Paneer Tikka",
+      27900,
+      "Char-grilled cottage cheese marinated in yogurt and spices.",
+      true,
+    ),
+  ]),
+  makeCategory("cat-breads", "Breads & Rice", [
+    makeItem(
+      "item-8",
+      "Garlic Naan",
+      7900,
+      "Soft naan brushed with garlic and butter.",
+      true,
+    ),
+    makeItem(
+      "item-9",
+      "Tandoori Roti",
+      4900,
+      "Whole-wheat flatbread from the tandoor.",
+      true,
+    ),
+    makeItem(
+      "item-10",
+      "Jeera Rice",
+      16900,
+      "Steamed basmati tempered with cumin.",
+      true,
+    ),
+  ]),
+  makeCategory("cat-desserts", "Desserts", [
+    makeItem(
+      "item-11",
+      "Gulab Jamun",
+      12900,
+      "Warm milk-solid dumplings in rose syrup.",
+      true,
+    ),
+    makeItem(
+      "item-12",
+      "Choco Lava Cake",
+      15900,
+      "Molten chocolate cake with a gooey centre.",
+      true,
+    ),
+  ]),
+  makeCategory("cat-beverages", "Beverages", [
+    makeItem(
+      "item-13",
+      "Masala Chaas",
+      6900,
+      "Spiced buttermilk, perfectly chilled.",
+      true,
+    ),
+    makeItem(
+      "item-14",
+      "Sweet Lassi",
+      9900,
+      "Thick, creamy yogurt drink.",
+      true,
+    ),
+    makeItem(
+      "item-15",
+      "Cold Coffee",
+      13900,
+      "Blended coffee with milk and ice.",
+      true,
+    ),
+  ]),
+];
+
+/**
+ * Sample menu shaped like the data `useMenu` builds for the page, plus
+ * `isSample: true` so the page can flag it as fallback content. Fetch-state
+ * fields (isLoading/isError) are intentionally left to the hook.
+ */
+export const SAMPLE_MENU = {
+  name: "FoodPeek Kitchen (Sample)",
+  avgRating: 4.4,
+  totalRatingsString: "12K+",
+  costForTwoMessage: "₹400 for two",
+  cuisines: ["North Indian", "Chinese", "Desserts"],
+  filterCategory,
+  areaName: "Koramangala",
+  locality: "Sample Locality",
+  city: "Bengaluru",
+  isSample: true,
+};

--- a/client/src/data/sampleRestaurants.js
+++ b/client/src/data/sampleRestaurants.js
@@ -1,0 +1,101 @@
+/**
+ * Sample Restaurant Data (Fallback)
+ *
+ * Deterministically expands the real seed entries in `utils/res-list.js`
+ * into 100+ unique restaurants that match the live API shape exactly
+ * (`{ info, analytics, cta }`). Used as a graceful fallback when the
+ * restaurant-list API errors out or returns an empty result.
+ *
+ * Generation is pure and deterministic (no randomness / no timestamps),
+ * so React keys stay stable across renders.
+ */
+
+import reslist from "../utils/res-list";
+
+/**
+ * Branch variants used to turn each real seed into several realistic
+ * "chain locations" across the city. Variant 0 keeps the original entry
+ * untouched; the rest are derived branches.
+ */
+const BRANCH_VARIANTS = [
+  null, // variant 0 — original seed, unchanged
+  {
+    locality: "Indiranagar",
+    areaName: "Indiranagar",
+    ratingDelta: 0.1,
+    deliveryDelta: 4,
+  },
+  {
+    locality: "HSR Layout",
+    areaName: "HSR Layout",
+    ratingDelta: -0.2,
+    deliveryDelta: 7,
+  },
+  {
+    locality: "Whitefield",
+    areaName: "Whitefield",
+    ratingDelta: 0.2,
+    deliveryDelta: 11,
+  },
+  {
+    locality: "Jayanagar",
+    areaName: "Jayanagar",
+    ratingDelta: -0.1,
+    deliveryDelta: 6,
+  },
+  {
+    locality: "Marathahalli",
+    areaName: "Marathahalli",
+    ratingDelta: 0.0,
+    deliveryDelta: 9,
+  },
+];
+
+const clampRating = (value) =>
+  Math.min(4.9, Math.max(3.0, Math.round(value * 10) / 10));
+
+/**
+ * Builds a single branch restaurant from a seed entry.
+ * @param {object} seed - A real restaurant entry from res-list.
+ * @param {number} variantIndex - Index into BRANCH_VARIANTS.
+ * @returns {object} A restaurant object in API shape with a unique id.
+ */
+const buildBranch = (seed, variantIndex) => {
+  const variant = BRANCH_VARIANTS[variantIndex];
+
+  // Plain-JSON deep clone — every seed is JSON-serializable.
+  const clone = JSON.parse(JSON.stringify(seed));
+
+  if (!variant) return clone; // variant 0: keep the original seed as-is
+
+  // Branch variants get a globally unique id so React keys never collide.
+  clone.info.id = `${seed.info.id}-${variantIndex}`;
+
+  const rating = clampRating(seed.info.avgRating + variant.ratingDelta);
+
+  clone.info.name = `${seed.info.name} - ${variant.areaName}`;
+  clone.info.locality = variant.locality;
+  clone.info.areaName = variant.areaName;
+  clone.info.avgRating = rating;
+  clone.info.avgRatingString = rating.toFixed(1);
+
+  if (clone.info.sla) {
+    clone.info.sla.deliveryTime =
+      (seed.info.sla?.deliveryTime ?? 25) + variant.deliveryDelta;
+  }
+
+  return clone;
+};
+
+/**
+ * Generates the full fallback dataset: every seed across every branch
+ * variant. With the current seeds (20) and variants (6) this yields 120
+ * unique restaurants — comfortably above the 100-item target.
+ */
+const generateSampleRestaurants = () =>
+  reslist.flatMap((seed) =>
+    BRANCH_VARIANTS.map((_, variantIndex) => buildBranch(seed, variantIndex)),
+  );
+
+/** Memoized fallback dataset (≥100 items). */
+export const SAMPLE_RESTAURANTS = generateSampleRestaurants();

--- a/client/src/features/menu/components/MenuSection.js
+++ b/client/src/features/menu/components/MenuSection.js
@@ -13,9 +13,7 @@ const MenuSection = ({ data }) => {
       </div>
       <div className="mt-10 mb-12 flex flex-wrap">
         {itemCards.map((item) => {
-          return (
-            <MenuBody itemInfo={item.card.info} key={item.card.info.name} />
-          );
+          return <MenuBody itemInfo={item.card.info} key={item.card.info.id} />;
         })}
       </div>
     </div>

--- a/client/src/features/restaurants/components/RestaurantList.js
+++ b/client/src/features/restaurants/components/RestaurantList.js
@@ -4,6 +4,7 @@ import { Link } from "react-router";
 import RestaurantCard, {
   useWithTopRatedLabel,
 } from "../../../components/common/RestaurantCard";
+import SampleDataNotice from "../../../components/common/SampleDataNotice";
 import Shimmer from "../../../components/common/Shimmer";
 import { useRestaurants } from "../../../hooks/useRestaurants";
 
@@ -13,8 +14,8 @@ const RestaurantList = () => {
 
   const [animationParent] = useAutoAnimate();
 
-  // Use SWR hook for data fetching
-  const { restaurants, isLoading, isError } = useRestaurants();
+  // Use SWR hook for data fetching. Falls back to sample data on error/empty.
+  const { restaurants, isLoading, isSample } = useRestaurants();
 
   const ResturantWithLabel = useWithTopRatedLabel(RestaurantCard);
 
@@ -55,19 +56,9 @@ const RestaurantList = () => {
     return <Shimmer />;
   }
 
-  // Error state
-  if (isError) {
-    return (
-      <div className="flex min-h-screen items-center justify-center">
-        <p className="text-xl text-red-500">
-          Failed to load restaurants. Please try again later.
-        </p>
-      </div>
-    );
-  }
-
   return (
     <div>
+      {isSample && <SampleDataNotice />}
       <div className="m-2 flex p-2 filter">
         <div className="search m-2 rounded-lg border border-slate-400 bg-blue-100 py-1 pl-2 shadow-md">
           <label htmlFor="restaurant-search" className="search-btn mr-2">

--- a/client/src/hooks/useMenu.js
+++ b/client/src/hooks/useMenu.js
@@ -1,10 +1,13 @@
 import useSWR from "swr";
 import { useParams } from "react-router";
 import { fetcher, API_ENDPOINTS } from "../services/api";
+import { SAMPLE_MENU } from "../data/sampleMenu";
 
 /**
  * Custom hook to fetch restaurant menu data
- * @returns {object} - Menu data with restaurant info and categories
+ * @returns {object|null} Menu data with restaurant info and categories, or
+ *   `null` while loading. Falls back to a sample menu (with `isSample: true`)
+ *   when the API errors out or returns no usable menu.
  */
 const useMenu = () => {
   const { restaurantId } = useParams();
@@ -14,54 +17,71 @@ const useMenu = () => {
     fetcher,
     {
       revalidateOnFocus: false,
-      dedupingInterval: 1300000,  
-    }
+      dedupingInterval: 1300000,
+    },
   );
 
-  if (isLoading || !data) return null;
-  if (error) return null;
+  // No restaurant in the route, or still fetching: show the loading state.
+  if (!restaurantId || isLoading) return null;
 
-  // Determine device type and get appropriate index
-  const userAgent = navigator.userAgent;
-  const indexSelect = /android|iphone/i.test(userAgent) ? 5 : 4;
+  // Sample menu carries the current fetch state alongside the static content.
+  const sampleMenu = { ...SAMPLE_MENU, isLoading: false, isError: error };
 
-  const menuData = data?.data;
+  // On error or a missing payload, fall back to the sample menu.
+  if (error || !data) return sampleMenu;
 
-  // Filter menu categories
-  const filterCategory = menuData?.cards[
-    indexSelect
-  ]?.groupedCard?.cardGroupMap?.REGULAR?.cards?.filter((element) => {
-    return (
-      element.card.card["@type"] ===
-      "type.googleapis.com/swiggy.presentation.food.v2.ItemCategory"
-    );
-  });
+  try {
+    // Determine device type and get appropriate index
+    const userAgent = navigator.userAgent;
+    const indexSelect = /android|iphone/i.test(userAgent) ? 5 : 4;
 
-  // Extract restaurant info
-  const {
-    name,
-    avgRating,
-    totalRatingsString,
-    costForTwoMessage,
-    cuisines,
-    areaName,
-    locality,
-    city,
-  } = menuData?.cards[2]?.card?.card?.info || {};
+    const menuData = data?.data;
 
-  return {
-    name,
-    avgRating,
-    totalRatingsString,
-    costForTwoMessage,
-    cuisines,
-    filterCategory,
-    areaName,
-    locality,
-    city,
-    isLoading,
-    isError: error,
-  };
+    // Filter menu categories
+    const filterCategory = menuData?.cards[
+      indexSelect
+    ]?.groupedCard?.cardGroupMap?.REGULAR?.cards?.filter((element) => {
+      return (
+        element?.card?.card?.["@type"] ===
+        "type.googleapis.com/swiggy.presentation.food.v2.ItemCategory"
+      );
+    });
+
+    // Extract restaurant info
+    const {
+      name,
+      avgRating,
+      totalRatingsString,
+      costForTwoMessage,
+      cuisines,
+      areaName,
+      locality,
+      city,
+    } = menuData?.cards[2]?.card?.card?.info || {};
+
+    // If the payload didn't contain a usable menu, fall back to sample data.
+    if (!name || !filterCategory || filterCategory.length === 0) {
+      return sampleMenu;
+    }
+
+    return {
+      name,
+      avgRating,
+      totalRatingsString,
+      costForTwoMessage,
+      cuisines,
+      filterCategory,
+      areaName,
+      locality,
+      city,
+      isLoading,
+      isError: error,
+      isSample: false,
+    };
+  } catch {
+    // Any unexpected shape in the live payload → graceful sample fallback.
+    return sampleMenu;
+  }
 };
 
 export default useMenu;

--- a/client/src/hooks/useRestaurants.js
+++ b/client/src/hooks/useRestaurants.js
@@ -1,39 +1,60 @@
 import useSWR from "swr";
 import { fetcher, API_ENDPOINTS } from "../services/api";
+import { SAMPLE_RESTAURANTS } from "../data/sampleRestaurants";
 
 /**
  * Custom hook to fetch restaurant list
  * @param {number} lat - Latitude
  * @param {number} lng - Longitude
- * @returns {object} - SWR response with data, error, isLoading
+ * @returns {object} - { restaurants, isLoading, isError, isSample, mutate }.
+ *   Falls back to a 100+ item sample dataset (with `isSample: true`) when the
+ *   API errors out or returns an empty list.
  */
 export const useRestaurants = (lat, lng) => {
-    const { data, error, isLoading, mutate } = useSWR(
-        API_ENDPOINTS.RESTAURANT_LIST(lat, lng),
-        fetcher,
-        {
-            revalidateOnFocus: false,
-            dedupingInterval: 60000, // Cache for 1 minute
-        }
+  const { data, error, isLoading, mutate } = useSWR(
+    API_ENDPOINTS.RESTAURANT_LIST(lat, lng),
+    fetcher,
+    {
+      revalidateOnFocus: false,
+      dedupingInterval: 60000, // Cache for 1 minute
+    },
+  );
+
+  // Determine device type and get appropriate index
+  const getRestaurantList = () => {
+    if (!data) return null;
+
+    const userAgent = navigator.userAgent;
+    const indexSelect = /android|iphone/i.test(userAgent) ? 2 : 1;
+
+    return (
+      data?.data?.cards[indexSelect]?.card?.card?.gridElements?.infoWithStyle
+        ?.restaurants || []
     );
+  };
 
-    // Determine device type and get appropriate index
-    const getRestaurantList = () => {
-        if (!data) return null;
-
-        const userAgent = navigator.userAgent;
-        const indexSelect = /android|iphone/i.test(userAgent) ? 2 : 1;
-
-        return (
-            data?.data?.cards[indexSelect]?.card?.card?.gridElements?.infoWithStyle
-                ?.restaurants || []
-        );
-    };
-
+  // Still fetching: let the UI show its loading state.
+  if (isLoading) {
     return {
-        restaurants: getRestaurantList(),
-        isLoading,
-        isError: error,
-        mutate,
+      restaurants: null,
+      isLoading,
+      isError: error,
+      isSample: false,
+      mutate,
     };
+  }
+
+  // Fall back to sample data on error or an empty/unusable response.
+  const restaurants = getRestaurantList();
+  if (error || !restaurants || restaurants.length === 0) {
+    return {
+      restaurants: SAMPLE_RESTAURANTS,
+      isLoading: false,
+      isError: error,
+      isSample: true,
+      mutate,
+    };
+  }
+
+  return { restaurants, isLoading, isError: error, isSample: false, mutate };
 };

--- a/client/src/pages/menu/Menu.js
+++ b/client/src/pages/menu/Menu.js
@@ -1,6 +1,7 @@
 import Shimmer from "../../components/common/Shimmer";
 
 import NoInternet from "../../components/common/NoInternet";
+import SampleDataNotice from "../../components/common/SampleDataNotice";
 import useOnlineStatus from "../../hooks/useOnlineStatus";
 
 import MenuSection from "../../features/menu/components/MenuSection";
@@ -16,10 +17,21 @@ const Menu = () => {
   if (menuData === null) {
     return <Shimmer />;
   }
-  const { name, cuisines, filterCategory, areaName, locality, city } = menuData;
+  const {
+    name,
+    cuisines = [],
+    filterCategory,
+    areaName,
+    locality,
+    city,
+    isSample,
+  } = menuData;
 
   return (
     <div>
+      {isSample && (
+        <SampleDataNotice message="Showing a sample menu — live menu is currently unavailable." />
+      )}
       <div className="relative h-44 w-full">
         <img
           className="absolute top-0 left-0 h-full w-full rounded-lg object-cover"


### PR DESCRIPTION
When the restaurant-list or menu API errors out or returns no usable data, the app now renders realistic sample content instead of an error or empty screen, with a visible notice so it is never mistaken for live data. Real data always takes precedence.

- data/sampleRestaurants.js: deterministic generator that reuses the real seeds in utils/res-list.js (previously unused) and expands them into 120 unique restaurants in exact API shape
- data/sampleMenu.js: sample menu matching useMenu's output shape
- components/common/SampleDataNotice.js: fallback notice banner
- hooks/useRestaurants.js + useMenu.js: fall back on error/empty (and on malformed menu payloads via try/catch); null only while loading
- RestaurantList.js / Menu.js: show the notice when isSample; Menu.js guards cuisines.join; MenuSection keys items by id instead of name